### PR TITLE
[TASK] Improve BOM traversal

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Maintainability](https://qlty.sh/gh/mteu/projects/sbom-parser/maintainability.svg)](https://qlty.sh/gh/mteu/projects/sbom-parser)
 [![PHP Version Require](https://poser.pugx.org/mteu/sbom-parser/require/php)](https://packagist.org/packages/mteu/sbom-parser)
 
-# CycloneDX SBOM Parser
+# CycloneDX SBOM Parser for PHP
 </div>
 
 CycloneDX SBOM (Software Bill of Materials) parser for PHP 8.3+. Supports

--- a/src/Entity/Bom.php
+++ b/src/Entity/Bom.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace mteu\SbomParser\Entity;
 
 use mteu\SbomParser\Entity\Vulnerability\Vulnerability;
+use mteu\SbomParser\Index\BomComponentIndex;
 
 /**
  * Bom.
@@ -70,55 +71,27 @@ final readonly class Bom
     }
 
     /**
-     * @return Component[]
+     * @return list<Component>
      */
     public function getAllComponents(): array
     {
-        $allComponents = [];
-
-        foreach (($this->components ?? []) as $component) {
-            $allComponents[] = $component;
-            $allComponents = array_merge($allComponents, $this->extractNestedComponents($component));
-        }
-
-        return $allComponents;
+        return BomComponentIndex::flatten($this);
     }
 
     /**
-     * @return Component[]
-     */
-    private function extractNestedComponents(Component $component): array
-    {
-        $nested = [];
-
-        foreach (($component->components ?? []) as $childComponent) {
-            $nested[] = $childComponent;
-            $nested = array_merge($nested, $this->extractNestedComponents($childComponent));
-        }
-
-        return $nested;
-    }
-
-    /**
-     * @return Component[]
+     * @return list<Component>
      */
     public function findComponentsByType(ComponentType $type): array
     {
-        return array_filter(
+        return array_values(array_filter(
             $this->getAllComponents(),
             static fn (Component $component): bool => $component->type === $type
-        );
+        ));
     }
 
     public function findComponentByPurl(string $purl): ?Component
     {
-        foreach ($this->getAllComponents() as $component) {
-            if ($component->purl === $purl) {
-                return $component;
-            }
-        }
-
-        return null;
+        return BomComponentIndex::byPurl($this)[$purl] ?? null;
     }
 
 

--- a/src/Index/BomComponentIndex.php
+++ b/src/Index/BomComponentIndex.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the package "mteu/sbom-parser".
+ *
+ * Copyright (C) 2025 Martin Adler <mteu@mailbox.org>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace mteu\SbomParser\Index;
+
+use mteu\SbomParser\Entity\Bom;
+use mteu\SbomParser\Entity\Component;
+
+/**
+ * BomComponentIndex.
+ *
+ * Stores per-instance traversal results in WeakMaps so they are released
+ * automatically when the owning Bom is garbage-collected.
+ *
+ * @internal
+ *
+ * @author Martin Adler <mteu@mailbox.org>
+ * @license GPL-3.0-or-later
+ */
+final class BomComponentIndex
+{
+    /** @var \WeakMap<Bom, list<Component>>|null */
+    private static ?\WeakMap $flatComponents = null;
+
+    /** @var \WeakMap<Bom, array<string, Component>>|null */
+    private static ?\WeakMap $purlIndex = null;
+
+    /**
+     * @return list<Component>
+     */
+    public static function flatten(Bom $bom): array
+    {
+        $cache = self::$flatComponents ??= new \WeakMap();
+
+        if ($cache->offsetExists($bom)) {
+            return $cache[$bom];
+        }
+
+        $flat = iterator_to_array(self::walk($bom->components ?? []), false);
+        $cache[$bom] = $flat;
+
+        return $flat;
+    }
+
+    /**
+     * @return array<string, Component>
+     */
+    public static function byPurl(Bom $bom): array
+    {
+        $cache = self::$purlIndex ??= new \WeakMap();
+
+        if ($cache->offsetExists($bom)) {
+            return $cache[$bom];
+        }
+
+        $index = [];
+        foreach (self::flatten($bom) as $component) {
+            if ($component->purl !== null && !array_key_exists($component->purl, $index)) {
+                $index[$component->purl] = $component;
+            }
+        }
+
+        $cache[$bom] = $index;
+
+        return $index;
+    }
+
+    /**
+     * Depth-first pre-order walk; the result is materialised lazily by
+     * the caller via iterator_to_array, avoiding intermediate array copies.
+     *
+     * @param iterable<Component> $components
+     * @return \Generator<int, Component>
+     */
+    private static function walk(iterable $components): \Generator
+    {
+        foreach ($components as $component) {
+            yield $component;
+            yield from self::walk($component->components ?? []);
+        }
+    }
+}

--- a/tests/Unit/Entity/BomTest.php
+++ b/tests/Unit/Entity/BomTest.php
@@ -30,6 +30,7 @@ use mteu\SbomParser\Entity\ComponentType;
 use mteu\SbomParser\Entity\Compositions;
 use mteu\SbomParser\Entity\Service;
 use mteu\SbomParser\Entity\Vulnerability\Vulnerability;
+use mteu\SbomParser\Index\BomComponentIndex;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -41,6 +42,7 @@ use PHPUnit\Framework\TestCase;
  * @license GPL-3.0-or-later
  */
 #[CoversClass(Bom::class)]
+#[CoversClass(BomComponentIndex::class)]
 final class BomTest extends TestCase
 {
     #[Test]

--- a/tests/Unit/Entity/BomTest.php
+++ b/tests/Unit/Entity/BomTest.php
@@ -333,4 +333,49 @@ final class BomTest extends TestCase
 
         self::assertSame($nestedComponent, $result);
     }
+
+    #[Test]
+    public function getAllComponentsReturnsConsistentResultsAcrossCalls(): void
+    {
+        $component = new Component(ComponentType::LIBRARY, 'lib1');
+        $nested = new Component(ComponentType::LIBRARY, 'nested');
+        $parent = new Component(ComponentType::APPLICATION, 'app', components: [$nested]);
+        $bom = new Bom('CycloneDX', '1.6', components: [$component, $parent]);
+
+        $first = $bom->getAllComponents();
+        $second = $bom->getAllComponents();
+
+        self::assertSame([$component, $parent, $nested], $first);
+        self::assertSame($first, $second);
+    }
+
+    #[Test]
+    public function findComponentByPurlReturnsConsistentResultsAcrossCalls(): void
+    {
+        $a = new Component(ComponentType::LIBRARY, 'a', purl: 'pkg:npm/a@1.0.0');
+        $b = new Component(ComponentType::LIBRARY, 'b', purl: 'pkg:npm/b@1.0.0');
+        $bom = new Bom('CycloneDX', '1.6', components: [$a, $b]);
+
+        self::assertSame($a, $bom->findComponentByPurl('pkg:npm/a@1.0.0'));
+        self::assertSame($b, $bom->findComponentByPurl('pkg:npm/b@1.0.0'));
+        self::assertSame($a, $bom->findComponentByPurl('pkg:npm/a@1.0.0'));
+        self::assertNull($bom->findComponentByPurl('pkg:npm/missing@1.0.0'));
+    }
+
+    #[Test]
+    public function getAllComponentsHandlesDeeplyNestedTreesInOrder(): void
+    {
+        $depth = 200;
+        $current = new Component(ComponentType::LIBRARY, "lib-{$depth}");
+        $expected = [$current];
+        for ($i = $depth - 1; $i >= 1; $i--) {
+            $current = new Component(ComponentType::LIBRARY, "lib-{$i}", components: [$current]);
+            array_unshift($expected, $current);
+        }
+
+        $bom = new Bom('CycloneDX', '1.6', components: [$current]);
+
+        self::assertCount($depth, $bom->getAllComponents());
+        self::assertSame($expected, $bom->getAllComponents());
+    }
 }

--- a/tests/Unit/Index/BomComponentIndexTest.php
+++ b/tests/Unit/Index/BomComponentIndexTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the package "mteu/sbom-parser".
+ *
+ * Copyright (C) 2025 Martin Adler <mteu@mailbox.org>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace mteu\SbomParser\Tests\Unit\Index;
+
+use mteu\SbomParser\Entity\Bom;
+use mteu\SbomParser\Entity\Component;
+use mteu\SbomParser\Entity\ComponentType;
+use mteu\SbomParser\Index\BomComponentIndex;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @author Martin Adler <mteu@mailbox.org>
+ * @license GPL-3.0-or-later
+ */
+#[CoversClass(BomComponentIndex::class)]
+final class BomComponentIndexTest extends TestCase
+{
+    #[Test]
+    public function flattenReturnsEmptyListWhenBomHasNoComponents(): void
+    {
+        $bom = new Bom('CycloneDX', '1.6');
+
+        self::assertSame([], BomComponentIndex::flatten($bom));
+    }
+
+    #[Test]
+    public function flattenWalksComponentsDepthFirstInOrder(): void
+    {
+        $grandchild = new Component(ComponentType::LIBRARY, 'grandchild');
+        $child = new Component(ComponentType::LIBRARY, 'child', components: [$grandchild]);
+        $sibling = new Component(ComponentType::LIBRARY, 'sibling');
+        $parent = new Component(ComponentType::APPLICATION, 'parent', components: [$child, $sibling]);
+        $bom = new Bom('CycloneDX', '1.6', components: [$parent]);
+
+        self::assertSame(
+            [$parent, $child, $grandchild, $sibling],
+            BomComponentIndex::flatten($bom),
+        );
+    }
+
+    #[Test]
+    public function flattenCachesPerBomInstance(): void
+    {
+        $bom = new Bom('CycloneDX', '1.6', components: [
+            new Component(ComponentType::LIBRARY, 'a'),
+        ]);
+
+        $first = BomComponentIndex::flatten($bom);
+        $second = BomComponentIndex::flatten($bom);
+
+        self::assertSame($first, $second);
+    }
+
+    #[Test]
+    public function flattenSegregatesCachesAcrossBomInstances(): void
+    {
+        $a = new Component(ComponentType::LIBRARY, 'a');
+        $b = new Component(ComponentType::LIBRARY, 'b');
+        $bomA = new Bom('CycloneDX', '1.6', components: [$a]);
+        $bomB = new Bom('CycloneDX', '1.6', components: [$b]);
+
+        self::assertSame([$a], BomComponentIndex::flatten($bomA));
+        self::assertSame([$b], BomComponentIndex::flatten($bomB));
+    }
+
+    #[Test]
+    public function byPurlReturnsEmptyMapWhenNoComponentsHavePurls(): void
+    {
+        $bom = new Bom('CycloneDX', '1.6', components: [
+            new Component(ComponentType::LIBRARY, 'no-purl'),
+        ]);
+
+        self::assertSame([], BomComponentIndex::byPurl($bom));
+    }
+
+    #[Test]
+    public function byPurlIndexesComponentsByTheirPurl(): void
+    {
+        $a = new Component(ComponentType::LIBRARY, 'symfony/console', purl: 'pkg:composer/symfony/console@7.1.0');
+        $b = new Component(ComponentType::LIBRARY, 'cuyz/valinor', purl: 'pkg:composer/cuyz/valinor@2.0.0');
+        $bom = new Bom('CycloneDX', '1.6', components: [$a, $b]);
+
+        $index = BomComponentIndex::byPurl($bom);
+
+        self::assertSame($a, $index['pkg:composer/symfony/console@7.1.0']);
+        self::assertSame($b, $index['pkg:composer/cuyz/valinor@2.0.0']);
+    }
+
+    #[Test]
+    public function byPurlSkipsComponentsWithoutPurl(): void
+    {
+        $withPurl = new Component(ComponentType::LIBRARY, 'symfony/console', purl: 'pkg:composer/symfony/console@7.1.0');
+        $withoutPurl = new Component(ComponentType::LIBRARY, 'no-purl');
+        $bom = new Bom('CycloneDX', '1.6', components: [$withPurl, $withoutPurl]);
+
+        self::assertSame(['pkg:composer/symfony/console@7.1.0' => $withPurl], BomComponentIndex::byPurl($bom));
+    }
+
+    #[Test]
+    public function byPurlKeepsFirstOccurrenceWhenPurlIsDuplicated(): void
+    {
+        $first = new Component(ComponentType::LIBRARY, 'first', purl: 'pkg:composer/symfony/console@7.1.0');
+        $second = new Component(ComponentType::LIBRARY, 'second', purl: 'pkg:composer/symfony/console@7.1.0');
+        $bom = new Bom('CycloneDX', '1.6', components: [$first, $second]);
+
+        self::assertSame($first, BomComponentIndex::byPurl($bom)['pkg:composer/symfony/console@7.1.0']);
+    }
+
+    #[Test]
+    public function byPurlIndexesNestedComponents(): void
+    {
+        $nested = new Component(ComponentType::LIBRARY, 'phpunit/phpunit', purl: 'pkg:composer/phpunit/phpunit@11.5.0');
+        $parent = new Component(ComponentType::APPLICATION, 'parent', components: [$nested]);
+        $bom = new Bom('CycloneDX', '1.6', components: [$parent]);
+
+        self::assertSame($nested, BomComponentIndex::byPurl($bom)['pkg:composer/phpunit/phpunit@11.5.0']);
+    }
+
+    #[Test]
+    public function byPurlCachesPerBomInstance(): void
+    {
+        $bom = new Bom('CycloneDX', '1.6', components: [
+            new Component(ComponentType::LIBRARY, 'symfony/console', purl: 'pkg:composer/symfony/console@7.1.0'),
+        ]);
+
+        $first = BomComponentIndex::byPurl($bom);
+        $second = BomComponentIndex::byPurl($bom);
+
+        self::assertSame($first, $second);
+    }
+}


### PR DESCRIPTION
The traversal is now a depth-first generator materialised once via `iterator_to_array`, which is linear in the number of components. Memoise the flat list and `Component` lookup map per `Bom` instance via a new static `WeakMap`.