### PR TITLE
[BUGFIX] Replace Unix-only absolute-path check

### DIFF
--- a/src/Parser/CycloneDxParser.php
+++ b/src/Parser/CycloneDxParser.php
@@ -208,15 +208,11 @@ final readonly class CycloneDxParser implements Parser
      */
     private function validateSbomPath(string $sbomFilePath): void
     {
-        // Ensure absolute path
-        if (!str_starts_with($sbomFilePath, '/')) {
+        if (!$this->isAbsolutePath($sbomFilePath)) {
             throw SbomParseException::validationFailed('SBOM file path must be absolute');
         }
 
-        // Check for directory traversal attempts using multiple methods
-        if (str_contains($sbomFilePath, '..') ||
-            str_contains($sbomFilePath, '%2e%2e') ||
-            str_contains($sbomFilePath, '%2E%2E')) {
+        if ($this->containsTraversalSegment($sbomFilePath)) {
             throw SbomParseException::validationFailed('Directory traversal not allowed in SBOM path');
         }
 
@@ -226,11 +222,9 @@ final readonly class CycloneDxParser implements Parser
             throw SbomParseException::validationFailed('SBOM directory does not exist or is not accessible');
         }
 
-        // Construct the expected file path and verify it matches the real path
         $fileName = basename($sbomFilePath);
-        $expectedRealPath = $realDirectory . '/' . $fileName;
+        $expectedRealPath = $realDirectory . DIRECTORY_SEPARATOR . $fileName;
 
-        // If the file exists, verify the real path matches the expected path
         if (file_exists($sbomFilePath)) {
             $realFilePath = realpath($sbomFilePath);
             if ($realFilePath === false || $realFilePath !== $expectedRealPath) {
@@ -238,7 +232,6 @@ final readonly class CycloneDxParser implements Parser
             }
         }
 
-        // Ensure reasonable file extension
         $allowedExtensions = ['.json'];
         $dotPosition = strrpos($sbomFilePath, '.');
         if ($dotPosition === false) {
@@ -248,6 +241,50 @@ final readonly class CycloneDxParser implements Parser
         if (!in_array($extension, $allowedExtensions, true)) {
             throw SbomParseException::validationFailed('SBOM file must have .json extension');
         }
+    }
+
+    /**
+     * Detects absolute paths in a cross-platform way: Unix (`/foo`),
+     * Windows drive (`C:\foo`, `C:/foo`), and UNC (`\\server\share`).
+     */
+    private function isAbsolutePath(string $path): bool
+    {
+        if ($path === '') {
+            return false;
+        }
+
+        if ($path[0] === '/') {
+            return true;
+        }
+
+        if (str_starts_with($path, '\\\\')) {
+            return true;
+        }
+
+        return preg_match('#^[A-Za-z]:[\\\\/]#', $path) === 1;
+    }
+
+    /**
+     * Detects traversal at the path-segment level so legitimate names
+     * like `foo..bar.json` or `data..backup/` are not falsely rejected.
+     */
+    private function containsTraversalSegment(string $path): bool
+    {
+        // Normalise URL-encoded dots so the segment check sees them too.
+        $normalized = preg_replace('/%2e/i', '.', $path) ?? $path;
+
+        $segments = preg_split('#[\\\\/]+#', $normalized);
+        if ($segments === false) {
+            return false;
+        }
+
+        foreach ($segments as $segment) {
+            if ($segment === '..') {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/tests/Unit/Parser/CycloneDxParserTest.php
+++ b/tests/Unit/Parser/CycloneDxParserTest.php
@@ -250,6 +250,119 @@ final class CycloneDxParserTest extends TestCase
     }
 
     #[Test]
+    public function parseFromFileAcceptsDoubleDotInsideFilename(): void
+    {
+        $filePath = $this->tempOutputDir . '/foo..bar.json';
+        file_put_contents($filePath, '{"bomFormat":"CycloneDX","specVersion":"1.5"}');
+
+        $bom = $this->subject->parseFromFile($filePath);
+
+        self::assertSame('CycloneDX', $bom->bomFormat);
+        self::assertSame('1.5', $bom->specVersion);
+    }
+
+    #[Test]
+    public function parseFromFileAcceptsDoubleDotInsideDirectoryName(): void
+    {
+        $directory = $this->tempOutputDir . '/data..backup';
+        mkdir($directory);
+        $filePath = $directory . '/sbom.json';
+        file_put_contents($filePath, '{"bomFormat":"CycloneDX","specVersion":"1.5"}');
+
+        $bom = $this->subject->parseFromFile($filePath);
+
+        self::assertSame('CycloneDX', $bom->bomFormat);
+    }
+
+    #[Test]
+    public function parseFromFileRejectsSymlinkPointingOutsideDirectory(): void
+    {
+        if (!function_exists('symlink')) {
+            self::markTestSkipped('symlink() not available on this platform');
+        }
+
+        $target = tempnam(sys_get_temp_dir(), 'sbom_symlink_target_');
+        self::assertNotFalse($target);
+        file_put_contents($target, '{"bomFormat":"CycloneDX","specVersion":"1.5"}');
+
+        $symlinkPath = $this->tempOutputDir . '/sbom.json';
+
+        set_error_handler(static fn () => true);
+        try {
+            $created = symlink($target, $symlinkPath);
+        } finally {
+            restore_error_handler();
+        }
+
+        if (!$created) {
+            unlink($target);
+            self::markTestSkipped('Could not create symlink (insufficient permissions)');
+        }
+
+        try {
+            $this->expectException(SbomParseException::class);
+            $this->expectExceptionMessage('Directory traversal not allowed in SBOM path');
+            $this->subject->parseFromFile($symlinkPath);
+        } finally {
+            if (is_link($symlinkPath) || file_exists($symlinkPath)) {
+                unlink($symlinkPath);
+            }
+            if (file_exists($target)) {
+                unlink($target);
+            }
+        }
+    }
+
+    #[Test]
+    #[DataProvider('isAbsolutePathProvider')]
+    public function isAbsolutePathRecognisesPlatformConventions(string $path, bool $expected): void
+    {
+        $reflection = new \ReflectionMethod(CycloneDxParser::class, 'isAbsolutePath');
+        self::assertSame($expected, $reflection->invoke($this->subject, $path));
+    }
+
+    /** @return \Generator<string, array{string, bool}> */
+    public static function isAbsolutePathProvider(): \Generator
+    {
+        yield 'unix absolute' => ['/tmp/sbom.json', true];
+        yield 'unix relative' => ['tmp/sbom.json', false];
+        yield 'empty string' => ['', false];
+        yield 'plain dot' => ['./sbom.json', false];
+
+        yield 'windows drive with backslash' => ['C:\\Users\\foo\\sbom.json', true];
+        yield 'windows drive with forward slash' => ['C:/Users/foo/sbom.json', true];
+        yield 'windows drive lowercase letter' => ['d:\\sbom.json', true];
+        yield 'windows drive without separator' => ['C:sbom.json', false];
+        yield 'colon-only is not absolute' => [':sbom', false];
+
+        yield 'unc path' => ['\\\\server\\share\\sbom.json', true];
+    }
+
+    #[Test]
+    #[DataProvider('containsTraversalSegmentProvider')]
+    public function containsTraversalSegmentDetectsOnlyRealTraversal(string $path, bool $expected): void
+    {
+        $reflection = new \ReflectionMethod(CycloneDxParser::class, 'containsTraversalSegment');
+        self::assertSame($expected, $reflection->invoke($this->subject, $path));
+    }
+
+    /** @return \Generator<string, array{string, bool}> */
+    public static function containsTraversalSegmentProvider(): \Generator
+    {
+        yield 'clean unix path' => ['/var/data/sbom.json', false];
+        yield 'literal traversal segment' => ['/tmp/../etc/sbom.json', true];
+        yield 'trailing traversal segment' => ['/var/data/..', true];
+        yield 'url-encoded lowercase' => ['/tmp/%2e%2e/etc/sbom.json', true];
+        yield 'url-encoded uppercase' => ['/tmp/%2E%2E/etc/sbom.json', true];
+        yield 'url-encoded mixed case' => ['/tmp/%2e%2E/etc/sbom.json', true];
+        yield 'double-dot inside filename is allowed' => ['/var/data/foo..bar.json', false];
+        yield 'double-dot inside directory is allowed' => ['/var/data..backup/sbom.json', false];
+        yield 'leading double-dot inside segment is allowed' => ['/var/..hidden/sbom.json', false];
+        yield 'trailing double-dot inside segment is allowed' => ['/var/hidden../sbom.json', false];
+        yield 'windows-style traversal segment' => ['C:\\Users\\..\\etc\\sbom.json', true];
+    }
+
+    #[Test]
     public function parseFromFileThrowsExceptionForUnreadableFile(): void
     {
         $filePath = tempnam($this->tempOutputDir, 'parse_json') . '.json';


### PR DESCRIPTION
Replace Unix-only absolute-path check `str_starts_with($sbomFilePath, '/')` with checks that support Windows paths.

Now recognises:
- Unix paths,
- Windows drive prefixes (`C:\`, `C:/`),
- and UNC paths (`\\server\share`).