### PR TITLE
[!!!][FEATURE] Make accepted file size configurable, lower default to 10MB

### DIFF
--- a/src/Parser/CycloneDxParser.php
+++ b/src/Parser/CycloneDxParser.php
@@ -46,13 +46,28 @@ use mteu\SbomParser\Exception\SbomParseException;
 final readonly class CycloneDxParser implements Parser
 {
     public const array SUPPORTED_VERSIONS = ['1.4', '1.5', '1.6', '1.7'];
-    private const int MAX_FILE_SIZE = 50 * 1024 * 1024; // 50MB
+
+    /**
+     * Default maximum size in bytes of an SBOM file passed to
+     * {@see parseFromFile()}.
+     * Please override via the constructor when working with legitimately large SBOMs.
+     */
+    public const int DEFAULT_MAX_FILE_SIZE = 10 * 1024 * 1024;
+
     private const int JSON_MAX_DEPTH = 64;
 
     private TreeMapper $mapper;
+    private int $maxFileSize;
 
-    public function __construct()
+    public function __construct(int $maxFileSize = self::DEFAULT_MAX_FILE_SIZE)
     {
+        if ($maxFileSize <= 0) {
+            throw new \InvalidArgumentException(
+                sprintf('maxFileSize must be a positive integer, got %d', $maxFileSize)
+            );
+        }
+
+        $this->maxFileSize = $maxFileSize;
         $this->mapper = (new MapperBuilder())
             ->supportDateFormats('Y-m-d\TH:i:s.u\Z', 'Y-m-d\TH:i:s\Z', \DateTimeImmutable::ATOM)
             ->allowSuperfluousKeys()
@@ -63,48 +78,16 @@ final readonly class CycloneDxParser implements Parser
     {
         $this->validateSbomPath($filePath);
 
+        $content = $this->readFile($filePath);
+        $data = $this->decodeJson($content);
+        unset($content);
 
-        if (!file_exists($filePath)) {
-            throw SbomParseException::validationFailed(sprintf('File not found: %s', $filePath));
-        }
-
-        if (!is_readable($filePath)) {
-            throw SbomParseException::validationFailed(sprintf('File not readable: %s', $filePath));
-        }
-
-        $fileSize = filesize($filePath);
-        if ($fileSize === false) {
-            throw SbomParseException::validationFailed(sprintf('Could not determine file size: %s', $filePath));
-        }
-
-        if ($fileSize > self::MAX_FILE_SIZE) {
-            throw SbomParseException::validationFailed(
-                sprintf('File too large: %d bytes (maximum: %d bytes)', $fileSize, self::MAX_FILE_SIZE)
-            );
-        }
-
-        $content = file_get_contents($filePath);
-        if ($content === false) {
-            throw SbomParseException::validationFailed(sprintf('Could not read file: %s', $filePath));
-        }
-
-        return $this->parseFromJson($content);
+        return $this->parseFromArray($data);
     }
 
     public function parseFromJson(string $json): Bom
     {
-        try {
-            $data = json_decode($json, true, self::JSON_MAX_DEPTH, JSON_THROW_ON_ERROR);
-        } catch (\JsonException $e) {
-            throw SbomParseException::invalidJson($e->getMessage(), $e);
-        }
-
-        if (!is_array($data)) {
-            throw SbomParseException::validationFailed('Decoded JSON is not an array');
-        }
-
-        /** @var array<string, mixed> $data */
-        return $this->parseFromArray($data);
+        return $this->parseFromArray($this->decodeJson($json));
     }
 
     /**
@@ -156,20 +139,64 @@ final readonly class CycloneDxParser implements Parser
     {
         try {
             $this->validateSbomPath($filePath);
-
-            if (!file_exists($filePath) || !is_readable($filePath)) {
-                return false;
-            }
-
-            $content = file_get_contents($filePath);
-            if ($content === false) {
-                return false;
-            }
+            $content = $this->readFile($filePath);
 
             return $this->isValidSbomJson($content);
         } catch (SbomParseException) {
             return false;
         }
+    }
+
+    /**
+     * @throws SbomParseException
+     */
+    private function readFile(string $filePath): string
+    {
+        if (!file_exists($filePath)) {
+            throw SbomParseException::validationFailed(sprintf('File not found: %s', $filePath));
+        }
+
+        if (!is_readable($filePath)) {
+            throw SbomParseException::validationFailed(sprintf('File not readable: %s', $filePath));
+        }
+
+        $fileSize = filesize($filePath);
+        if ($fileSize === false) {
+            throw SbomParseException::validationFailed(sprintf('Could not determine file size: %s', $filePath));
+        }
+
+        if ($fileSize > $this->maxFileSize) {
+            throw SbomParseException::validationFailed(
+                sprintf('File too large: %d bytes (maximum: %d bytes)', $fileSize, $this->maxFileSize)
+            );
+        }
+
+        $content = file_get_contents($filePath);
+        if ($content === false) {
+            throw SbomParseException::validationFailed(sprintf('Could not read file: %s', $filePath));
+        }
+
+        return $content;
+    }
+
+    /**
+     * @return array<string, mixed>
+     * @throws SbomParseException
+     */
+    private function decodeJson(string $json): array
+    {
+        try {
+            $data = json_decode($json, true, self::JSON_MAX_DEPTH, JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            throw SbomParseException::invalidJson($e->getMessage(), $e);
+        }
+
+        if (!is_array($data)) {
+            throw SbomParseException::validationFailed('Decoded JSON is not an array');
+        }
+
+        /** @var array<string, mixed> $data */
+        return $data;
     }
 
     public function isValidSbomJson(string $json): bool

--- a/tests/Unit/Parser/CycloneDxParserTest.php
+++ b/tests/Unit/Parser/CycloneDxParserTest.php
@@ -377,21 +377,63 @@ final class CycloneDxParserTest extends TestCase
     #[Test]
     public function parseFromFileThrowsExceptionForFileTooLarge(): void
     {
-        $filePath = tempnam($this->tempOutputDir, 'large_file') . '.json';
+        $maxFileSize = 256;
+        $parser = new CycloneDxParser($maxFileSize);
 
-        $largeContent = str_repeat('a', 1024 * 1024);
-        $handle = fopen($filePath, 'w');
-        if ($handle === false) {
-            self::fail('Could not open file for writing');
-        }
-        for ($i = 0; $i < 52; $i++) {
-            fwrite($handle, $largeContent);
-        }
-        fclose($handle);
+        $filePath = tempnam($this->tempOutputDir, 'large_file') . '.json';
+        file_put_contents($filePath, str_repeat('a', $maxFileSize + 1));
 
         $this->expectException(SbomParseException::class);
         $this->expectExceptionMessage('File too large');
-        $this->subject->parseFromFile($filePath);
+        $parser->parseFromFile($filePath);
+    }
+
+    #[Test]
+    public function parseFromFileAcceptsFileWithinCustomMaxFileSize(): void
+    {
+        $payload = '{"bomFormat":"CycloneDX","specVersion":"1.5"}';
+        $parser = new CycloneDxParser(strlen($payload) + 1);
+
+        $filePath = tempnam($this->tempOutputDir, 'within_cap') . '.json';
+        file_put_contents($filePath, $payload);
+
+        $bom = $parser->parseFromFile($filePath);
+
+        self::assertSame('1.5', $bom->specVersion);
+    }
+
+    #[Test]
+    public function defaultMaxFileSizeMatchesPublicConstant(): void
+    {
+        self::assertSame(10 * 1024 * 1024, CycloneDxParser::DEFAULT_MAX_FILE_SIZE);
+    }
+
+    #[Test]
+    #[DataProvider('invalidMaxFileSizeProvider')]
+    public function constructorRejectsNonPositiveMaxFileSize(int $invalid): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('maxFileSize must be a positive integer');
+        new CycloneDxParser($invalid);
+    }
+
+    /** @return \Generator<string, array{int}> */
+    public static function invalidMaxFileSizeProvider(): \Generator
+    {
+        yield 'zero' => [0];
+        yield 'negative one' => [-1];
+        yield 'large negative' => [-1024 * 1024];
+    }
+
+    #[Test]
+    public function isValidSbomFileReturnsFalseForFileExceedingMaxSize(): void
+    {
+        $parser = new CycloneDxParser(64);
+
+        $filePath = tempnam($this->tempOutputDir, 'over_cap') . '.json';
+        file_put_contents($filePath, str_repeat('a', 256));
+
+        self::assertFalse($parser->isValidSbomFile($filePath));
     }
 
     /** @return \Generator<string, array{string, string}> */


### PR DESCRIPTION
Replace the private `MAX_FILE_SIZE` constant with a configurable constructor argument and a public `DEFAULT_MAX_FILE_SIZE` constant set to **10 MiB**.

Breaking: Callers that legitimately handle larger SBOMs must now opt in via `new CycloneDxParser($bytes)`.