### PR TITLE
[FEATURE] Introduce `CycloneDxParserOptions`

### DIFF
--- a/docs/cyclonedx-parser.md
+++ b/docs/cyclonedx-parser.md
@@ -91,13 +91,32 @@ if ($parser->isValidSbomArray($decodedData)) {
 }
 ```
 
-## File Size Limit
+## Configuration
 
-`parseFromFile` and `isValidSbomFile` enforce a default cap of 10 MiB (`CycloneDxParser::DEFAULT_MAX_FILE_SIZE`). Pass a custom limit in bytes to the constructor to raise it:
+`CycloneDxParser` is configured via an immutable `CycloneDxParserOptions` DTO. Default construction needs no arguments:
 
 ```php
-$parser = new CycloneDxParser(50 * 1024 * 1024); // 50 MiB
+$parser = new CycloneDxParser();
 ```
+
+To override defaults, build a `CycloneDxParserOptions` and pass it in:
+
+```php
+use mteu\SbomParser\Parser\Configuration\CycloneDxParserOptions;
+use mteu\SbomParser\Parser\CycloneDxParser;
+
+$options = new CycloneDxParserOptions(maxFileSize: 50 * 1024 * 1024);
+$parser = new CycloneDxParser($options);
+
+// Or use the fluent `with*` mutator:
+$parser = new CycloneDxParser(
+    (new CycloneDxParserOptions())->withMaxFileSize(50 * 1024 * 1024),
+);
+```
+
+### File size limit
+
+`parseFromFile` and `isValidSbomFile` enforce a default cap of 10 MiB (`CycloneDxParserOptions::DEFAULT_MAX_FILE_SIZE`). Raise it by configuring `maxFileSize` on the options DTO as shown above.
 
 ## Error Handling
 

--- a/src/Parser/Configuration/CycloneDxParserOptions.php
+++ b/src/Parser/Configuration/CycloneDxParserOptions.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the package "mteu/sbom-parser".
+ *
+ * Copyright (C) 2026 Martin Adler <mteu@mailbox.org>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace mteu\SbomParser\Parser\Configuration;
+
+/**
+ * Immutable configuration for {@see \mteu\SbomParser\Parser\CycloneDxParser}.
+ *
+ * @author Martin Adler <mteu@mailbox.org>
+ * @license GPL-3.0-or-later
+ */
+final readonly class CycloneDxParserOptions
+{
+    /**
+     * Default maximum size in bytes of an SBOM file passed to
+     * {@see \mteu\SbomParser\Parser\CycloneDxParser::parseFromFile()}.
+     * Override via {@see withMaxFileSize()} when working with
+     * legitimately large SBOMs.
+     */
+    public const int DEFAULT_MAX_FILE_SIZE = 10 * 1024 * 1024;
+
+    public function __construct(
+        public int $maxFileSize = self::DEFAULT_MAX_FILE_SIZE,
+    ) {
+        if ($maxFileSize <= 0) {
+            throw new \InvalidArgumentException(
+                sprintf('maxFileSize must be a positive integer, got %d', $maxFileSize)
+            );
+        }
+    }
+
+    public function withMaxFileSize(int $bytes): self
+    {
+        return new self(maxFileSize: $bytes);
+    }
+}

--- a/src/Parser/CycloneDxParser.php
+++ b/src/Parser/CycloneDxParser.php
@@ -34,6 +34,7 @@ use mteu\SbomParser\Entity\ComponentType;
 use mteu\SbomParser\Entity\ExternalReferenceType;
 use mteu\SbomParser\Entity\HashAlgorithm;
 use mteu\SbomParser\Exception\SbomParseException;
+use mteu\SbomParser\Parser\Configuration\CycloneDxParserOptions;
 
 /**
  * Type-Safe SBOM Parser.
@@ -47,27 +48,13 @@ final readonly class CycloneDxParser implements Parser
 {
     public const array SUPPORTED_VERSIONS = ['1.4', '1.5', '1.6', '1.7'];
 
-    /**
-     * Default maximum size in bytes of an SBOM file passed to
-     * {@see parseFromFile()}.
-     * Please override via the constructor when working with legitimately large SBOMs.
-     */
-    public const int DEFAULT_MAX_FILE_SIZE = 10 * 1024 * 1024;
-
     private const int JSON_MAX_DEPTH = 64;
 
     private TreeMapper $mapper;
-    private int $maxFileSize;
 
-    public function __construct(int $maxFileSize = self::DEFAULT_MAX_FILE_SIZE)
-    {
-        if ($maxFileSize <= 0) {
-            throw new \InvalidArgumentException(
-                sprintf('maxFileSize must be a positive integer, got %d', $maxFileSize)
-            );
-        }
-
-        $this->maxFileSize = $maxFileSize;
+    public function __construct(
+        private CycloneDxParserOptions $options = new CycloneDxParserOptions(),
+    ) {
         $this->mapper = (new MapperBuilder())
             ->supportDateFormats('Y-m-d\TH:i:s.u\Z', 'Y-m-d\TH:i:s\Z', \DateTimeImmutable::ATOM)
             ->allowSuperfluousKeys()
@@ -165,9 +152,9 @@ final readonly class CycloneDxParser implements Parser
             throw SbomParseException::validationFailed(sprintf('Could not determine file size: %s', $filePath));
         }
 
-        if ($fileSize > $this->maxFileSize) {
+        if ($fileSize > $this->options->maxFileSize) {
             throw SbomParseException::validationFailed(
-                sprintf('File too large: %d bytes (maximum: %d bytes)', $fileSize, $this->maxFileSize)
+                sprintf('File too large: %d bytes (maximum: %d bytes)', $fileSize, $this->options->maxFileSize)
             );
         }
 

--- a/tests/Unit/Parser/Configuration/CycloneDxParserOptionsTest.php
+++ b/tests/Unit/Parser/Configuration/CycloneDxParserOptionsTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the package "mteu/sbom-parser".
+ *
+ * Copyright (C) 2026 Martin Adler <mteu@mailbox.org>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace mteu\SbomParser\Tests\Unit\Parser\Configuration;
+
+use mteu\SbomParser\Parser\Configuration\CycloneDxParserOptions;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @author Martin Adler <mteu@mailbox.org>
+ * @license GPL-3.0-or-later
+ */
+#[CoversClass(CycloneDxParserOptions::class)]
+final class CycloneDxParserOptionsTest extends TestCase
+{
+    #[Test]
+    #[DataProvider('invalidMaxFileSizeProvider')]
+    public function constructorRejectsNonPositiveMaxFileSize(int $invalid): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('maxFileSize must be a positive integer');
+        new CycloneDxParserOptions(maxFileSize: $invalid);
+    }
+
+    /** @return \Generator<string, array{int}> */
+    public static function invalidMaxFileSizeProvider(): \Generator
+    {
+        yield 'zero' => [0];
+        yield 'negative one' => [-1];
+        yield 'large negative' => [-1024 * 1024];
+    }
+
+    #[Test]
+    public function withMaxFileSizeReturnsNewInstance(): void
+    {
+        $original = new CycloneDxParserOptions(maxFileSize: 1024);
+        $mutated = $original->withMaxFileSize(2048);
+
+        self::assertNotSame($original, $mutated);
+        self::assertSame(1024, $original->maxFileSize);
+        self::assertSame(2048, $mutated->maxFileSize);
+    }
+
+    #[Test]
+    public function withMaxFileSizeValidatesNewValue(): void
+    {
+        $original = new CycloneDxParserOptions();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('maxFileSize must be a positive integer');
+        $original->withMaxFileSize(0);
+    }
+}

--- a/tests/Unit/Parser/CycloneDxParserTest.php
+++ b/tests/Unit/Parser/CycloneDxParserTest.php
@@ -25,6 +25,7 @@ namespace mteu\SbomParser\Tests\Unit\Parser;
 
 use mteu\SbomParser\Entity\Bom;
 use mteu\SbomParser\Exception\SbomParseException;
+use mteu\SbomParser\Parser\Configuration\CycloneDxParserOptions;
 use mteu\SbomParser\Parser\CycloneDxParser;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -38,6 +39,7 @@ use PHPUnit\Framework\TestCase;
  * @license GPL-3.0-or-later
  */
 #[CoversClass(CycloneDxParser::class)]
+#[CoversClass(CycloneDxParserOptions::class)]
 #[CoversClass(SbomParseException::class)]
 final class CycloneDxParserTest extends TestCase
 {
@@ -378,7 +380,7 @@ final class CycloneDxParserTest extends TestCase
     public function parseFromFileThrowsExceptionForFileTooLarge(): void
     {
         $maxFileSize = 256;
-        $parser = new CycloneDxParser($maxFileSize);
+        $parser = new CycloneDxParser(new CycloneDxParserOptions(maxFileSize: $maxFileSize));
 
         $filePath = tempnam($this->tempOutputDir, 'large_file') . '.json';
         file_put_contents($filePath, str_repeat('a', $maxFileSize + 1));
@@ -392,7 +394,7 @@ final class CycloneDxParserTest extends TestCase
     public function parseFromFileAcceptsFileWithinCustomMaxFileSize(): void
     {
         $payload = '{"bomFormat":"CycloneDX","specVersion":"1.5"}';
-        $parser = new CycloneDxParser(strlen($payload) + 1);
+        $parser = new CycloneDxParser(new CycloneDxParserOptions(maxFileSize: strlen($payload) + 1));
 
         $filePath = tempnam($this->tempOutputDir, 'within_cap') . '.json';
         file_put_contents($filePath, $payload);
@@ -403,32 +405,9 @@ final class CycloneDxParserTest extends TestCase
     }
 
     #[Test]
-    public function defaultMaxFileSizeMatchesPublicConstant(): void
-    {
-        self::assertSame(10 * 1024 * 1024, CycloneDxParser::DEFAULT_MAX_FILE_SIZE);
-    }
-
-    #[Test]
-    #[DataProvider('invalidMaxFileSizeProvider')]
-    public function constructorRejectsNonPositiveMaxFileSize(int $invalid): void
-    {
-        $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('maxFileSize must be a positive integer');
-        new CycloneDxParser($invalid);
-    }
-
-    /** @return \Generator<string, array{int}> */
-    public static function invalidMaxFileSizeProvider(): \Generator
-    {
-        yield 'zero' => [0];
-        yield 'negative one' => [-1];
-        yield 'large negative' => [-1024 * 1024];
-    }
-
-    #[Test]
     public function isValidSbomFileReturnsFalseForFileExceedingMaxSize(): void
     {
-        $parser = new CycloneDxParser(64);
+        $parser = new CycloneDxParser(new CycloneDxParserOptions(maxFileSize: 64));
 
         $filePath = tempnam($this->tempOutputDir, 'over_cap') . '.json';
         file_put_contents($filePath, str_repeat('a', 256));


### PR DESCRIPTION
PR #180 introduced a way to override the lowered `fileSize` limit. This approach is changed in favor of an optional `CycloneDxParserOptions` DTO that can be passed as an argument to the `CycloneDxParser` reducing the parser constructor o a single argument:

```php
public function __construct(
    private CycloneDxParserOptions $options = new CycloneDxParserOptions(),
)
```

Overriding the allowed `fileSize` now requires this option DTO.

```php
$options = new CycloneDxParserOptions(maxFileSize: 50 * 1024 * 1024);
$parser = new CycloneDxParser($options);
```

Defaults remain as is.