### PR TITLE
[!!!][FEATURE] Add maxNodes option

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "~8.3.0 || ~8.4.0 || ~8.5.0",
-        "cuyz/valinor": "^2.0"
+        "cuyz/valinor": "^2.4"
     },
     "require-dev": {
         "armin/editorconfig-cli": "^2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "83fb9416ced5452fd77a612fdc1b5e61",
+    "content-hash": "980b4d18eee0ae0e87632201168f1f3b",
     "packages": [
         {
             "name": "cuyz/valinor",

--- a/docs/cyclonedx-parser.md
+++ b/docs/cyclonedx-parser.md
@@ -105,18 +105,32 @@ To override defaults, build a `CycloneDxParserOptions` and pass it in:
 use mteu\SbomParser\Parser\Configuration\CycloneDxParserOptions;
 use mteu\SbomParser\Parser\CycloneDxParser;
 
-$options = new CycloneDxParserOptions(maxFileSize: 50 * 1024 * 1024);
+$options = new CycloneDxParserOptions(
+    maxFileSize: 50 * 1024 * 1024,
+    maxNodes: 5_000_000,
+);
+
 $parser = new CycloneDxParser($options);
 
-// Or use the fluent `with*` mutator:
+// Or use the fluent `with*` mutator or any of these options while preserving the other option(s).
 $parser = new CycloneDxParser(
     (new CycloneDxParserOptions())->withMaxFileSize(50 * 1024 * 1024),
+);
+
+$parser = new CycloneDxParser(
+    (new CycloneDxParserOptions())->withMaxNodes(5_000_000),
 );
 ```
 
 ### File size limit
 
 `parseFromFile` and `isValidSbomFile` enforce a default cap of 10 MiB (`CycloneDxParserOptions::DEFAULT_MAX_FILE_SIZE`). Raise it by configuring `maxFileSize` on the options DTO as shown above.
+
+### Max node limit
+
+`parseFromArray` enforces a default maximum total node count in the decoded SBOM tree of `1_000_000` nodes to parsed (`CycloneDxParserOptions::DEFAULT_MAX_NODES`). Raise it by configuring `maxNodes` on the options DTO as shown above.
+
+
 
 ## Error Handling
 

--- a/src/Parser/Configuration/CycloneDxParserOptions.php
+++ b/src/Parser/Configuration/CycloneDxParserOptions.php
@@ -39,18 +39,38 @@ final readonly class CycloneDxParserOptions
      */
     public const int DEFAULT_MAX_FILE_SIZE = 10 * 1024 * 1024;
 
+    /**
+     * Default maximum total node count in the decoded SBOM tree. Caps
+     * wide payloads that would otherwise pass the file-size limit but
+     * still exhaust memory once decoded. Override via {@see withMaxNodes()}
+     * when working with legitimately very large SBOMs.
+     */
+    public const int DEFAULT_MAX_NODES = 1_000_000;
+
     public function __construct(
         public int $maxFileSize = self::DEFAULT_MAX_FILE_SIZE,
+        public int $maxNodes = self::DEFAULT_MAX_NODES,
     ) {
         if ($maxFileSize <= 0) {
             throw new \InvalidArgumentException(
                 sprintf('maxFileSize must be a positive integer, got %d', $maxFileSize)
             );
         }
+
+        if ($maxNodes <= 0) {
+            throw new \InvalidArgumentException(
+                sprintf('maxNodes must be a positive integer, got %d', $maxNodes)
+            );
+        }
     }
 
     public function withMaxFileSize(int $bytes): self
     {
-        return new self(maxFileSize: $bytes);
+        return new self(maxFileSize: $bytes, maxNodes: $this->maxNodes);
+    }
+
+    public function withMaxNodes(int $count): self
+    {
+        return new self(maxFileSize: $this->maxFileSize, maxNodes: $count);
     }
 }

--- a/src/Parser/CycloneDxParser.php
+++ b/src/Parser/CycloneDxParser.php
@@ -24,15 +24,9 @@ declare(strict_types=1);
 namespace mteu\SbomParser\Parser;
 
 use CuyZ\Valinor\Mapper\MappingError;
-use CuyZ\Valinor\Mapper\Tree\Message\Messages;
-use CuyZ\Valinor\Mapper\Tree\Message\NodeMessage;
 use CuyZ\Valinor\Mapper\TreeMapper;
 use CuyZ\Valinor\MapperBuilder;
 use mteu\SbomParser\Entity\Bom;
-use mteu\SbomParser\Entity\Component;
-use mteu\SbomParser\Entity\ComponentType;
-use mteu\SbomParser\Entity\ExternalReferenceType;
-use mteu\SbomParser\Entity\HashAlgorithm;
 use mteu\SbomParser\Exception\SbomParseException;
 use mteu\SbomParser\Parser\Configuration\CycloneDxParserOptions;
 
@@ -57,6 +51,9 @@ final readonly class CycloneDxParser implements Parser
     ) {
         $this->mapper = (new MapperBuilder())
             ->supportDateFormats('Y-m-d\TH:i:s.u\Z', 'Y-m-d\TH:i:s\Z', \DateTimeImmutable::ATOM)
+            ->registerKeyConverter(
+                static fn (string $key): string => $key === 'bom-ref' ? 'bomRef' : $key,
+            )
             ->allowSuperfluousKeys()
             ->mapper();
     }
@@ -83,7 +80,7 @@ final readonly class CycloneDxParser implements Parser
     public function parseFromArray(array $data): Bom
     {
         $this->validateDataStructure($data);
-        $data = $this->normalizeHyphenatedKeys($data);
+        $this->enforceNodeBudget($data);
 
         try {
             return $this->mapper->map(Bom::class, $data);
@@ -96,24 +93,36 @@ final readonly class CycloneDxParser implements Parser
     }
 
     /**
-     * @param mixed[] $data
-     * @return array<string, mixed>
+     * Walk the decoded structure once and abort if the total number of
+     * values exceeds {@see CycloneDxParserOptions::$maxNodes}. Protects
+     * against wide JSON payloads that fit under the file-size cap but
+     * would otherwise blow up memory during Valinor mapping.
+     *
+     * @param array<int|string, mixed> $data
+     * @throws SbomParseException
      */
-    private function normalizeHyphenatedKeys(array $data): array
+    private function enforceNodeBudget(array $data): void
     {
-        $keyMap = [
-            'bom-ref' => 'bomRef',
-        ];
+        $count = 0;
+        $stack = [$data];
 
-        $result = [];
-        foreach ($data as $key => $value) {
-            $normalizedKey = $keyMap[(string) $key] ?? (string) $key;
-            $result[$normalizedKey] = is_array($value)
-                ? $this->normalizeHyphenatedKeys($value)
-                : $value;
+        while ($stack !== []) {
+            $current = array_pop($stack);
+            foreach ($current as $value) {
+                $count++;
+                if ($count > $this->options->maxNodes) {
+                    throw SbomParseException::validationFailed(
+                        sprintf(
+                            'Decoded SBOM exceeds maximum node count of %d',
+                            $this->options->maxNodes,
+                        )
+                    );
+                }
+                if (is_array($value)) {
+                    $stack[] = $value;
+                }
+            }
         }
-
-        return $result;
     }
 
     /** @codeCoverageIgnore */

--- a/tests/Unit/Parser/Configuration/CycloneDxParserOptionsTest.php
+++ b/tests/Unit/Parser/Configuration/CycloneDxParserOptionsTest.php
@@ -54,6 +54,23 @@ final class CycloneDxParserOptionsTest extends TestCase
     }
 
     #[Test]
+    #[DataProvider('invalidMaxNodesProvider')]
+    public function constructorRejectsNonPositiveMaxNodes(int $invalid): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('maxNodes must be a positive integer');
+        new CycloneDxParserOptions(maxNodes: $invalid);
+    }
+
+    /** @return \Generator<string, array{int}> */
+    public static function invalidMaxNodesProvider(): \Generator
+    {
+        yield 'zero' => [0];
+        yield 'negative one' => [-1];
+        yield 'large negative' => [-1_000_000];
+    }
+
+    #[Test]
     public function withMaxFileSizeReturnsNewInstance(): void
     {
         $original = new CycloneDxParserOptions(maxFileSize: 1024);
@@ -72,5 +89,46 @@ final class CycloneDxParserOptionsTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('maxFileSize must be a positive integer');
         $original->withMaxFileSize(0);
+    }
+
+    #[Test]
+    public function withMaxFileSizePreservesOtherFields(): void
+    {
+        $original = new CycloneDxParserOptions(maxFileSize: 1024, maxNodes: 500);
+        $mutated = $original->withMaxFileSize(2048);
+
+        self::assertSame(2048, $mutated->maxFileSize);
+        self::assertSame(500, $mutated->maxNodes);
+    }
+
+    #[Test]
+    public function withMaxNodesReturnsNewInstance(): void
+    {
+        $original = new CycloneDxParserOptions(maxNodes: 100);
+        $mutated = $original->withMaxNodes(200);
+
+        self::assertNotSame($original, $mutated);
+        self::assertSame(100, $original->maxNodes);
+        self::assertSame(200, $mutated->maxNodes);
+    }
+
+    #[Test]
+    public function withMaxNodesValidatesNewValue(): void
+    {
+        $original = new CycloneDxParserOptions();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('maxNodes must be a positive integer');
+        $original->withMaxNodes(0);
+    }
+
+    #[Test]
+    public function withMaxNodesPreservesOtherFields(): void
+    {
+        $original = new CycloneDxParserOptions(maxFileSize: 1024, maxNodes: 100);
+        $mutated = $original->withMaxNodes(200);
+
+        self::assertSame(1024, $mutated->maxFileSize);
+        self::assertSame(200, $mutated->maxNodes);
     }
 }

--- a/tests/Unit/Parser/CycloneDxParserTest.php
+++ b/tests/Unit/Parser/CycloneDxParserTest.php
@@ -415,6 +415,82 @@ final class CycloneDxParserTest extends TestCase
         self::assertFalse($parser->isValidSbomFile($filePath));
     }
 
+    #[Test]
+    public function parseFromArrayRejectsPayloadExceedingNodeBudget(): void
+    {
+        $parser = new CycloneDxParser(new CycloneDxParserOptions(maxNodes: 10));
+
+        $components = [];
+        for ($i = 0; $i < 100; $i++) {
+            $components[] = ['type' => 'library', 'name' => "lib-{$i}"];
+        }
+
+        $data = [
+            'bomFormat' => 'CycloneDX',
+            'specVersion' => '1.6',
+            'components' => $components,
+        ];
+
+        $this->expectException(SbomParseException::class);
+        $this->expectExceptionMessage('Decoded SBOM exceeds maximum node count of 10');
+        $parser->parseFromArray($data);
+    }
+
+    #[Test]
+    public function parseFromArrayAcceptsPayloadWithinNodeBudget(): void
+    {
+        $parser = new CycloneDxParser(new CycloneDxParserOptions(maxNodes: 100));
+
+        $bom = $parser->parseFromArray([
+            'bomFormat' => 'CycloneDX',
+            'specVersion' => '1.6',
+            'components' => [['type' => 'library', 'name' => 'lib']],
+        ]);
+
+        self::assertSame('CycloneDX', $bom->bomFormat);
+    }
+
+    #[Test]
+    public function parseFromJsonRejectsWidePayloadExceedingNodeBudget(): void
+    {
+        $parser = new CycloneDxParser(new CycloneDxParserOptions(maxNodes: 50));
+
+        $wide = [];
+        for ($i = 0; $i < 200; $i++) {
+            $wide["k{$i}"] = $i;
+        }
+
+        $json = (string) json_encode([
+            'bomFormat' => 'CycloneDX',
+            'specVersion' => '1.6',
+            'metadata' => ['properties' => $wide],
+        ]);
+
+        $this->expectException(SbomParseException::class);
+        $this->expectExceptionMessage('Decoded SBOM exceeds maximum node count');
+        $parser->parseFromJson($json);
+    }
+
+    #[Test]
+    public function parseFromArrayRenamesBomRefToBomRef(): void
+    {
+        $bom = $this->subject->parseFromArray([
+            'bomFormat' => 'CycloneDX',
+            'specVersion' => '1.6',
+            'components' => [
+                [
+                    'type' => 'library',
+                    'name' => 'symfony/console',
+                    'bom-ref' => 'composer/symfony/console',
+                ],
+            ],
+        ]);
+
+        $components = $bom->components ?? [];
+        self::assertCount(1, $components);
+        self::assertSame('composer/symfony/console', $components[0]->bomRef);
+    }
+
     /** @return \Generator<string, array{string, string}> */
     public static function parseFromFileFixtureProvider(): \Generator
     {


### PR DESCRIPTION
This PR ships a new option for the `CycloneDxParser` that caps the maximal amount of nodes to be parsed. Default amount was set to `1_000_000` nodes. Override with:

```php
$parser = new CycloneDxParser(
    new CycloneDxParserOptions(maxNodes: 5_000_000),
);
```

The mutation `withMaxFileSize()` now preserves `maxNodes` and vice versa.

Additionally, the way the `bom-ref` key is normalized now uses the [`\CuyZ\Valinor\MapperBuilder::registerKeyConverter`](https://github.com/CuyZ/Valinor/commit/bfd4ab10766322bcbde4fe796ed8cab276d4acf1) method dropping a redundant and rather expensive tree walk. Consequently, this package now requires `cuyz/valinor: ^2.4`.

