### PR TITLE
[FEATURE] Add optional base-directory allowlist for parseFromFile

### DIFF
--- a/docs/cyclonedx-parser.md
+++ b/docs/cyclonedx-parser.md
@@ -105,20 +105,21 @@ To override defaults, build a `CycloneDxParserOptions` and pass it in:
 use mteu\SbomParser\Parser\Configuration\CycloneDxParserOptions;
 use mteu\SbomParser\Parser\CycloneDxParser;
 
+// All arguments are optional
 $options = new CycloneDxParserOptions(
     maxFileSize: 50 * 1024 * 1024,
     maxNodes: 5_000_000,
+    allowedBaseDirectories: ['/srv/sboms'],
 );
 
 $parser = new CycloneDxParser($options);
 
-// Or use the fluent `with*` mutator or any of these options while preserving the other option(s).
+// Or use the fluent `with*` mutators to change individual options while preserving the others.
 $parser = new CycloneDxParser(
-    (new CycloneDxParserOptions())->withMaxFileSize(50 * 1024 * 1024),
-);
-
-$parser = new CycloneDxParser(
-    (new CycloneDxParserOptions())->withMaxNodes(5_000_000),
+    (new CycloneDxParserOptions())
+        ->withMaxFileSize(50 * 1024 * 1024)
+        ->withMaxNodes(5_000_000)
+        ->withAllowedBaseDirectories(['/srv/sboms', '/var/www/bom']),
 );
 ```
 
@@ -130,7 +131,25 @@ $parser = new CycloneDxParser(
 
 `parseFromArray` enforces a default maximum total node count in the decoded SBOM tree of `1_000_000` nodes to parsed (`CycloneDxParserOptions::DEFAULT_MAX_NODES`). Raise it by configuring `maxNodes` on the options DTO as shown above.
 
+### Allowed base directories
 
+`parseFromFile` and `isValidSbomFile` perform absolute-path and directory-traversal
+checks on every call, but by default they will happily read any `.json` file the
+PHP process has access to. When the file path comes from untrusted input (HTTP request,
+queue payload, CLI argument), restrict reads to a known set of directories by configuring
+`allowedBaseDirectories`:
+
+```php
+$parser = new CycloneDxParser(
+    new CycloneDxParserOptions(allowedBaseDirectories: ['/srv/sboms']),
+);
+
+// Accepted - resolves under /srv/sboms
+$parser->parseFromFile('/srv/sboms/customer-42/bom.json');
+
+// Rejected - SbomParseException
+$parser->parseFromFile('/etc/passwd.json');
+```
 
 ## Error Handling
 

--- a/src/Parser/Configuration/CycloneDxParserOptions.php
+++ b/src/Parser/Configuration/CycloneDxParserOptions.php
@@ -47,9 +47,19 @@ final readonly class CycloneDxParserOptions
      */
     public const int DEFAULT_MAX_NODES = 1_000_000;
 
+    /**
+     * @param list<string> $allowedBaseDirectories Absolute directory prefixes that
+     *     {@see \mteu\SbomParser\Parser\CycloneDxParser::parseFromFile()} is allowed
+     *     to read from. An empty list (the default) imposes no restriction and
+     *     preserves the permissive library behaviour. When the list is non-empty,
+     *     the resolved real path of the SBOM file must live under one of the
+     *     allowed prefixes; otherwise the parser rejects the call. Set this when
+     *     the file path originates from untrusted input.
+     */
     public function __construct(
         public int $maxFileSize = self::DEFAULT_MAX_FILE_SIZE,
         public int $maxNodes = self::DEFAULT_MAX_NODES,
+        public array $allowedBaseDirectories = [],
     ) {
         if ($maxFileSize <= 0) {
             throw new \InvalidArgumentException(
@@ -62,15 +72,43 @@ final readonly class CycloneDxParserOptions
                 sprintf('maxNodes must be a positive integer, got %d', $maxNodes)
             );
         }
+
+        foreach ($allowedBaseDirectories as $directory) {
+            if ($directory === '') {
+                throw new \InvalidArgumentException(
+                    'allowedBaseDirectories entries must be non-empty strings'
+                );
+            }
+        }
     }
 
     public function withMaxFileSize(int $bytes): self
     {
-        return new self(maxFileSize: $bytes, maxNodes: $this->maxNodes);
+        return new self(
+            maxFileSize: $bytes,
+            maxNodes: $this->maxNodes,
+            allowedBaseDirectories: $this->allowedBaseDirectories,
+        );
     }
 
     public function withMaxNodes(int $count): self
     {
-        return new self(maxFileSize: $this->maxFileSize, maxNodes: $count);
+        return new self(
+            maxFileSize: $this->maxFileSize,
+            maxNodes: $count,
+            allowedBaseDirectories: $this->allowedBaseDirectories,
+        );
+    }
+
+    /**
+     * @param list<string> $directories
+     */
+    public function withAllowedBaseDirectories(array $directories): self
+    {
+        return new self(
+            maxFileSize: $this->maxFileSize,
+            maxNodes: $this->maxNodes,
+            allowedBaseDirectories: $directories,
+        );
     }
 }

--- a/src/Parser/CycloneDxParser.php
+++ b/src/Parser/CycloneDxParser.php
@@ -255,6 +255,14 @@ final readonly class CycloneDxParser implements Parser
             }
         }
 
+        if ($this->options->allowedBaseDirectories !== []
+            && !$this->isWithinAllowedBaseDirectory($expectedRealPath)
+        ) {
+            throw SbomParseException::validationFailed(
+                'SBOM file path is outside the allowed base directories'
+            );
+        }
+
         $allowedExtensions = ['.json'];
         $dotPosition = strrpos($sbomFilePath, '.');
         if ($dotPosition === false) {
@@ -285,6 +293,29 @@ final readonly class CycloneDxParser implements Parser
         }
 
         return preg_match('#^[A-Za-z]:[\\\\/]#', $path) === 1;
+    }
+
+    /**
+     * Verifies that the resolved SBOM path lives under one of the
+     * configured allowed base directories. Each prefix is normalised
+     * via realpath() so symlinked or relative entries resolve to a
+     * canonical absolute form before the comparison.
+     */
+    private function isWithinAllowedBaseDirectory(string $resolvedFilePath): bool
+    {
+        foreach ($this->options->allowedBaseDirectories as $allowed) {
+            $realAllowed = realpath($allowed);
+            if ($realAllowed === false) {
+                continue;
+            }
+
+            $needle = rtrim($realAllowed, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+            if (str_starts_with($resolvedFilePath, $needle)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/tests/Unit/Parser/Configuration/CycloneDxParserOptionsTest.php
+++ b/tests/Unit/Parser/Configuration/CycloneDxParserOptionsTest.php
@@ -125,10 +125,81 @@ final class CycloneDxParserOptionsTest extends TestCase
     #[Test]
     public function withMaxNodesPreservesOtherFields(): void
     {
-        $original = new CycloneDxParserOptions(maxFileSize: 1024, maxNodes: 100);
+        $original = new CycloneDxParserOptions(
+            maxFileSize: 1024,
+            maxNodes: 100,
+            allowedBaseDirectories: ['/srv/sboms'],
+        );
         $mutated = $original->withMaxNodes(200);
 
         self::assertSame(1024, $mutated->maxFileSize);
         self::assertSame(200, $mutated->maxNodes);
+        self::assertSame(['/srv/sboms'], $mutated->allowedBaseDirectories);
+    }
+
+    #[Test]
+    public function allowedBaseDirectoriesDefaultsToEmptyList(): void
+    {
+        $options = new CycloneDxParserOptions();
+
+        self::assertSame([], $options->allowedBaseDirectories);
+    }
+
+    #[Test]
+    public function customAllowedBaseDirectoriesAreStored(): void
+    {
+        $directories = ['/srv/sboms', '/var/data/sboms'];
+        $options = new CycloneDxParserOptions(allowedBaseDirectories: $directories);
+
+        self::assertSame($directories, $options->allowedBaseDirectories);
+    }
+
+    #[Test]
+    public function constructorRejectsEmptyAllowedBaseDirectoryEntry(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('allowedBaseDirectories entries must be non-empty strings');
+        new CycloneDxParserOptions(allowedBaseDirectories: ['/srv/sboms', '']);
+    }
+
+    #[Test]
+    public function withAllowedBaseDirectoriesReturnsNewInstance(): void
+    {
+        $original = new CycloneDxParserOptions(allowedBaseDirectories: ['/srv/a']);
+        $mutated = $original->withAllowedBaseDirectories(['/srv/b']);
+
+        self::assertNotSame($original, $mutated);
+        self::assertSame(['/srv/a'], $original->allowedBaseDirectories);
+        self::assertSame(['/srv/b'], $mutated->allowedBaseDirectories);
+    }
+
+    #[Test]
+    public function withAllowedBaseDirectoriesValidatesNewValue(): void
+    {
+        $original = new CycloneDxParserOptions();
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('allowedBaseDirectories entries must be non-empty strings');
+        $original->withAllowedBaseDirectories(['']);
+    }
+
+    #[Test]
+    public function withAllowedBaseDirectoriesPreservesOtherFields(): void
+    {
+        $original = new CycloneDxParserOptions(maxFileSize: 1024, maxNodes: 100);
+        $mutated = $original->withAllowedBaseDirectories(['/srv/sboms']);
+
+        self::assertSame(1024, $mutated->maxFileSize);
+        self::assertSame(100, $mutated->maxNodes);
+        self::assertSame(['/srv/sboms'], $mutated->allowedBaseDirectories);
+    }
+
+    #[Test]
+    public function withMaxFileSizePreservesAllowedBaseDirectories(): void
+    {
+        $original = new CycloneDxParserOptions(allowedBaseDirectories: ['/srv/sboms']);
+        $mutated = $original->withMaxFileSize(2048);
+
+        self::assertSame(['/srv/sboms'], $mutated->allowedBaseDirectories);
     }
 }

--- a/tests/Unit/Parser/CycloneDxParserTest.php
+++ b/tests/Unit/Parser/CycloneDxParserTest.php
@@ -416,6 +416,125 @@ final class CycloneDxParserTest extends TestCase
     }
 
     #[Test]
+    public function parseFromFileAcceptsPathWithinAllowedBaseDirectory(): void
+    {
+        $base = (string) realpath($this->tempOutputDir);
+        $parser = new CycloneDxParser(
+            new CycloneDxParserOptions(allowedBaseDirectories: [$base]),
+        );
+
+        $filePath = $this->tempOutputDir . '/sbom.json';
+        file_put_contents($filePath, '{"bomFormat":"CycloneDX","specVersion":"1.5"}');
+
+        $bom = $parser->parseFromFile($filePath);
+
+        self::assertSame('1.5', $bom->specVersion);
+    }
+
+    #[Test]
+    public function parseFromFileRejectsPathOutsideAllowedBaseDirectory(): void
+    {
+        $allowed = $this->tempOutputDir . '/allowed';
+        $other = $this->tempOutputDir . '/other';
+        mkdir($allowed, 0755, true);
+        mkdir($other, 0755, true);
+
+        $parser = new CycloneDxParser(
+            new CycloneDxParserOptions(allowedBaseDirectories: [(string) realpath($allowed)]),
+        );
+
+        $filePath = $other . '/sbom.json';
+        file_put_contents($filePath, '{"bomFormat":"CycloneDX","specVersion":"1.5"}');
+
+        $this->expectException(SbomParseException::class);
+        $this->expectExceptionMessage('SBOM file path is outside the allowed base directories');
+        $parser->parseFromFile($filePath);
+    }
+
+    #[Test]
+    public function parseFromFileAcceptsPathWithinAnyOfMultipleAllowedDirectories(): void
+    {
+        $first = $this->tempOutputDir . '/first';
+        $second = $this->tempOutputDir . '/second';
+        mkdir($first, 0755, true);
+        mkdir($second, 0755, true);
+
+        $parser = new CycloneDxParser(
+            new CycloneDxParserOptions(
+                allowedBaseDirectories: [
+                    (string) realpath($first),
+                    (string) realpath($second),
+                ],
+            ),
+        );
+
+        $filePath = $second . '/sbom.json';
+        file_put_contents($filePath, '{"bomFormat":"CycloneDX","specVersion":"1.5"}');
+
+        $bom = $parser->parseFromFile($filePath);
+
+        self::assertSame('1.5', $bom->specVersion);
+    }
+
+    #[Test]
+    public function parseFromFileRejectsSiblingDirectoryWithSharedPrefix(): void
+    {
+        $allowed = $this->tempOutputDir . '/data';
+        $sibling = $this->tempOutputDir . '/data-other';
+        mkdir($allowed, 0755, true);
+        mkdir($sibling, 0755, true);
+
+        $parser = new CycloneDxParser(
+            new CycloneDxParserOptions(allowedBaseDirectories: [(string) realpath($allowed)]),
+        );
+
+        $filePath = $sibling . '/sbom.json';
+        file_put_contents($filePath, '{"bomFormat":"CycloneDX","specVersion":"1.5"}');
+
+        $this->expectException(SbomParseException::class);
+        $this->expectExceptionMessage('SBOM file path is outside the allowed base directories');
+        $parser->parseFromFile($filePath);
+    }
+
+    #[Test]
+    public function parseFromFileIgnoresAllowedBaseDirectoriesWhenEmpty(): void
+    {
+        $parser = new CycloneDxParser(
+            new CycloneDxParserOptions(allowedBaseDirectories: []),
+        );
+
+        $filePath = $this->tempOutputDir . '/sbom.json';
+        file_put_contents($filePath, '{"bomFormat":"CycloneDX","specVersion":"1.5"}');
+
+        $bom = $parser->parseFromFile($filePath);
+
+        self::assertSame('1.5', $bom->specVersion);
+    }
+
+    #[Test]
+    public function parseFromFileSkipsNonExistentAllowedBaseDirectory(): void
+    {
+        $allowed = $this->tempOutputDir . '/real';
+        mkdir($allowed, 0755, true);
+
+        $parser = new CycloneDxParser(
+            new CycloneDxParserOptions(
+                allowedBaseDirectories: [
+                    $this->tempOutputDir . '/does-not-exist',
+                    (string) realpath($allowed),
+                ],
+            ),
+        );
+
+        $filePath = $allowed . '/sbom.json';
+        file_put_contents($filePath, '{"bomFormat":"CycloneDX","specVersion":"1.5"}');
+
+        $bom = $parser->parseFromFile($filePath);
+
+        self::assertSame('1.5', $bom->specVersion);
+    }
+
+    #[Test]
     public function parseFromArrayRejectsPayloadExceedingNodeBudget(): void
     {
         $parser = new CycloneDxParser(new CycloneDxParserOptions(maxNodes: 10));


### PR DESCRIPTION
Adds an optional path-allowlist to `parseFromFile()` so callers that pass user-influenced paths can restrict reads to one or more directories.

`CycloneDxParserOptions` gains a third field alongside `maxFileSize` and `maxNodes`:

```php
public function __construct(
    public int $maxFileSize = self::DEFAULT_MAX_FILE_SIZE,
    public int $maxNodes = self::DEFAULT_MAX_NODES,
    public array $allowedBaseDirectories = [],
)
```

Override the loose default with:
```php
$parser = new CycloneDxParser(
    new CycloneDxParserOptions(allowedBaseDirectories: ['/srv/sboms']),
);
```