### PR TITLE
[BUGFIX] Fix composer type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "mteu/sbom-parser",
     "description": "Type-safe parser for CycloneDX Software Bill of Materials (SBOM) JSON files",
     "license": "GPL-3.0-or-later",
-    "type": "package",
+    "type": "library",
     "authors": [
         {
             "name": "Martin Adler",


### PR DESCRIPTION
Resolves #195.

In `composer.json`: `"type": "package"` is set -- which is no valid value according to the docs: [getcomposer.org/doc/04-schema.md#type](https://getcomposer.org/doc/04-schema.md#type)

Thanks for pointing that out @jkowalleck!
